### PR TITLE
Handle inaccuracy of `getTimeZoneTransition` method in `startOf...` and `endOf...` functions

### DIFF
--- a/src/datetime/_endOfTimeForZonedDateTime.ts
+++ b/src/datetime/_endOfTimeForZonedDateTime.ts
@@ -1,4 +1,5 @@
 import type { Temporal } from "../types.js";
+import { getTimeZoneTransitionBetween } from "./_getTimeZoneTransitionBetween.js";
 
 /** @internal */
 export function endOfTimeForZonedDateTime(
@@ -18,10 +19,8 @@ export function endOfTimeForZonedDateTime(
 		return later;
 	} else {
 		// forward transition
-		const transition = earlier.getTimeZoneTransition("next");
-		if (transition === null) {
-			throw new Error("Unknown error");
-		}
-		return transition.subtract({ nanoseconds: 1 });
+		return getTimeZoneTransitionBetween(earlier, later).subtract({
+			nanoseconds: 1,
+		});
 	}
 }

--- a/src/datetime/_getTimeZoneTransitionBetween.test.ts
+++ b/src/datetime/_getTimeZoneTransitionBetween.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+
+import { getTimeZoneTransitionBetween } from "./_getTimeZoneTransitionBetween.js";
+
+test("getTimeZoneTransitionBetween", () => {
+	const transition1 = Temporal.ZonedDateTime.from(
+		"2024-03-31T02:00:00+01:00[Europe/London]",
+	);
+	const transition2 = Temporal.ZonedDateTime.from(
+		"2024-10-27T01:00:00+00:00[Europe/London]",
+	);
+	expect(
+		getTimeZoneTransitionBetween(
+			transition1.subtract({ nanoseconds: 1 }),
+			transition1,
+		),
+	).toEqual(transition1);
+	expect(getTimeZoneTransitionBetween(transition1, transition2)).toEqual(
+		transition2,
+	);
+});
+
+test("getTimeZoneTransitionBetween and non-ISO calendar", () => {
+	const transition = Temporal.ZonedDateTime.from(
+		"2024-03-31T02:00:00+01:00[Europe/London][u-ca=hebrew]",
+	);
+	expect(
+		getTimeZoneTransitionBetween(
+			transition.subtract({ nanoseconds: 1 }),
+			transition,
+		),
+	).toEqual(transition);
+});

--- a/src/datetime/_getTimeZoneTransitionBetween.ts
+++ b/src/datetime/_getTimeZoneTransitionBetween.ts
@@ -1,0 +1,44 @@
+import { getConstructor } from "../type-utils.js";
+import type { Temporal } from "../types.js";
+import { isNativeMethod } from "./_isNativeMethod.js";
+
+/**
+ * @internal
+ * `getTimeZoneTransition` method can return inaccurate result in polyfill (see https://github.com/tc39/proposal-temporal/issues/3110).
+ * However, if it is guaranteed that only 1 time zone transition occurs within the given range,
+ * we can make sure to return a correct result using binary search.
+ *
+ */
+export function getTimeZoneTransitionBetween(
+	start: Temporal.ZonedDateTime,
+	end: Temporal.ZonedDateTime,
+): Temporal.ZonedDateTime {
+	if (start.offsetNanoseconds === end.offsetNanoseconds) {
+		throw new Error("Unknown error");
+	}
+	if (isNativeMethod(start, "getTimeZoneTransition")) {
+		const transition = start.getTimeZoneTransition("next");
+		if (transition === null) {
+			throw new Error("Unknown error");
+		}
+		return transition;
+	}
+	const Instant = getConstructor(start.toInstant());
+	// assumption: no sub-second offset nor offset transition in fractional seconds
+	let left = Math.floor(start.epochMilliseconds / 1000);
+	let right = Math.floor(end.epochMilliseconds / 1000);
+	while (right - left > 1) {
+		const mid = Math.floor((left + right) / 2);
+		const midOffset = Instant.fromEpochMilliseconds(
+			mid * 1000,
+		).toZonedDateTimeISO(start).offsetNanoseconds;
+		if (midOffset === start.offsetNanoseconds) {
+			left = mid;
+		} else {
+			right = mid;
+		}
+	}
+	return Instant.fromEpochMilliseconds(right * 1000)
+		.toZonedDateTimeISO(start)
+		.withCalendar(start);
+}

--- a/src/datetime/_isNativeMethod.ts
+++ b/src/datetime/_isNativeMethod.ts
@@ -1,0 +1,23 @@
+/**
+ * @internal
+ * This method is not reliable when a polyfill overwrites `Function.prototype.toString` (as core-js do),
+ * but neither `temporal-polyfill` or `@js-temporal/polyfill` does that.
+ */
+export function isNativeMethod<T>(obj: T, name: keyof T): boolean {
+	return new RegExp(
+		[
+			"^function",
+			name,
+			"\\(",
+			"[^)]*",
+			"\\)",
+			"\\{",
+			"\\[",
+			"native",
+			"code",
+			"\\]",
+			"\\}",
+			"$",
+		].join("\\s*"),
+	).test(Function.prototype.toString.call(obj[name]));
+}

--- a/src/datetime/_startOfTimeForZonedDateTime.ts
+++ b/src/datetime/_startOfTimeForZonedDateTime.ts
@@ -1,4 +1,5 @@
 import type { Temporal } from "../types.js";
+import { getTimeZoneTransitionBetween } from "./_getTimeZoneTransitionBetween.js";
 
 /** @internal */
 export function startOfTimeForZonedDateTime(
@@ -18,10 +19,6 @@ export function startOfTimeForZonedDateTime(
 		return earlier;
 	} else {
 		// forward transition
-		const start = earlier.getTimeZoneTransition("next");
-		if (start === null) {
-			throw new Error("Unknown error");
-		}
-		return start;
+		return getTimeZoneTransitionBetween(earlier, later);
 	}
 }

--- a/src/datetime/startOfDay.test.ts
+++ b/src/datetime/startOfDay.test.ts
@@ -62,3 +62,20 @@ test("ZonedDateTime and forward transition", () => {
 		Temporal.ZonedDateTime.from("1919-03-31T00:30:00-04:00[America/Toronto]"),
 	);
 });
+
+test("ZonedDateTime with `getTimeZoneTransition` edge case", () => {
+	// temporary workaround for https://github.com/fullcalendar/temporal-polyfill/issues/73
+	// skip the test for `temporal-polyfill`
+	// TODO: remove the workaround when the bug is fixed
+	let zdt;
+	try {
+		zdt = Temporal.ZonedDateTime.from(
+			"2000-10-08T01:00:00-03:00[America/Boa_Vista]",
+		);
+	} catch {
+		return;
+	}
+	expect(startOfDay(zdt)).toEqual(
+		Temporal.ZonedDateTime.from("2000-10-08T01:00:00-03:00[America/Boa_Vista]"),
+	);
+});

--- a/src/datetime/startOfDay.ts
+++ b/src/datetime/startOfDay.ts
@@ -1,5 +1,7 @@
 import { isZonedDateTime } from "../type-utils.js";
 import type { Temporal } from "../types.js";
+import { isNativeMethod } from "./_isNativeMethod.js";
+import { startOfTimeForZonedDateTime } from "./_startOfTimeForZonedDateTime.js";
 
 /**
  * Returns the start of a day for the given datetime
@@ -9,15 +11,18 @@ import type { Temporal } from "../types.js";
 export function startOfDay<
 	DateTime extends Temporal.PlainDateTime | Temporal.ZonedDateTime,
 >(dt: DateTime): DateTime {
+	const withArg = {
+		hour: 0,
+		minute: 0,
+		second: 0,
+		millisecond: 0,
+		microsecond: 0,
+		nanosecond: 0,
+	};
+	// `startOfDay` method can return wrong result in polyfill (see https://github.com/tc39/proposal-temporal/issues/3110)
 	return (
 		isZonedDateTime(dt) ?
-			dt.startOfDay()
-		:	dt.with({
-				hour: 0,
-				minute: 0,
-				second: 0,
-				millisecond: 0,
-				microsecond: 0,
-				nanosecond: 0,
-			})) as DateTime;
+			isNativeMethod(dt, "startOfDay") ? dt.startOfDay()
+			:	startOfTimeForZonedDateTime(dt, withArg)
+		:	dt.with(withArg)) as DateTime;
 }


### PR DESCRIPTION
`Temporal.ZonedDateTime.prototype.getTimeZoneTransition` method can return an incorrect result in polyfill due to a fundamental technical limitation. See https://github.com/tc39/proposal-temporal/issues/3110, note that the fix (https://github.com/tc39/proposal-temporal/pull/3112) won't work on unseen future edge cases until they are hardcoded.

The method is used in `startOf...` and `endOf...` functions in vremel, but our only usage is finding an offset transition within the range of at most 24 hours (theoretically 48 hours?) which for sure includes only 1 transition. In such case we can do a binary search on our own to get a correct result.

Note that polyfill can implement `Temporal.ZonedDateTime.prototype.startOfDay` method with 100% correctness but current polyfills still have a bug. This PR make `startOfDay` function avoid using it too.